### PR TITLE
Use numpy legacy output format when doing doctests

### DIFF
--- a/test.py
+++ b/test.py
@@ -13,6 +13,14 @@ Usage:
 import os, sys
 import nose
 
+# Whitespace changes between numpy 1.13 and 1.14 will cause the doctests
+# to fail; when doctests are updated to 1.14 format, this can be removed.
+try:    # CRUFT
+    import numpy as np
+    np.set_printoptions(legacy='1.13')
+except TypeError:
+    pass
+
 # Check that we are running from the root.
 path = os.getcwd()
 assert os.path.exists(os.path.join(path,'periodictable','nsf.py'))


### PR DESCRIPTION
numpy 1.14 changes the output format for printing and would break the doctests throughout; tell numpy to use the 1.13 format instead.

(would you like a pytest.ini and conftest.py for pytest and use them instead of nose?)