### PR TITLE
Use wt% and vol% for mixtures instead of %wt  and %vol

### DIFF
--- a/doc/sphinx/guide/formula_grammar.rst
+++ b/doc/sphinx/guide/formula_grammar.rst
@@ -91,17 +91,17 @@ A formula string is translated into a formula using
     >>> print("%.3f"%formula("2D2O + H2O@1n").density)
     1.074
 
-* Mass fractions use %wt, with the final portion adding to 100%:
+* Mass fractions use wt%, with the final portion adding to 100%:
 
-    >>> print(formula("10%wt Fe // 15% Co // Ni"))
+    >>> print(formula("10wt% Fe // 15% Co // Ni"))
     FeCo1.4214Ni7.13602
 
   Only the first item needs to specify that it is a mass fraction,
   and the remainder can use a bare %.
 
-* Volume fractions use %vol, with the final portion adding to 100%:
+* Volume fractions use vol%, with the final portion adding to 100%:
 
-    >>> print(formula("10%vol Fe // Ni"))
+    >>> print(formula("10vol% Fe // Ni"))
     FeNi9.68121
 
   Only the first item needs to specify that it is a volume fraction, and
@@ -134,7 +134,7 @@ A formula string is translated into a formula using
 * Mixtures can nest.  The following is a 10% salt solution by weight mixed
   20:80 by volume with D2O:
 
-    >>> print(formula("20%vol (10%wt NaCl@2.16 // H2O@1) // D2O@1n"))
+    >>> print(formula("20vol% (10 wt% NaCl@2.16 // H2O@1) // D2O@1n"))
     NaCl(H2O)29.1966(D2O)122.794
 
 * Empty formulas are supported, e.g., for air or vacuum:
@@ -151,7 +151,7 @@ The grammar used for parsing formula strings is the following:
     formula    :: compound | mixture | nothing
     mixture    :: quantity | percentage
     quantity   :: count unit part ('//' count unit part)*
-    percentage :: count '%wt|%vol' part ('//' count '%' part)* '//' part
+    percentage :: count 'wt%|vol%' part ('//' count '%' part)* '//' part
     part       :: compound | '(' mixture ')'
     compound   :: group (separator group)* density?
     group      :: count element+ | '(' formula ')' count
@@ -206,7 +206,7 @@ to those isotopes used.
 This makes heavy water density easily specified as:
 
     >>> D2O = formula('D2O',natural_density=1)
-    >>> print("%s %.4g"%(D2O,D2O.density))
+    >>> print(f"{D2O} {D2O.density:.4g}")
     D2O 1.112
 
 Density can also be estimated from the volume of the unit cell, either
@@ -223,19 +223,20 @@ Because the packing fraction method relies on the covalent radius
 estimate it is not very accurate:
 
     >>> from periodictable import elements, formula
-    >>> Fe = formula("2Fe")  # bcc lattice has 2 atoms per unit cell
-    >>> Fe.density = Fe.molecular_mass/Fe.volume('bcc')
-    >>> print("%.3g"%Fe.density)
+    >>> Fe_bcc = formula("2Fe")  # bcc lattice has 2 atoms per unit cell
+    >>> Fe_bcc.density = Fe_bcc.molecular_mass/Fe_bcc.volume('bcc')
+    >>> print(f"{Fe_bcc.density:.3g}")
     6.55
-    >>> print("%.3g"%elements.Fe.density)
+    >>> print(f"{elements.Fe.density:.3g}")
     7.87
 
 Using lattice parameters the results are much better:
 
-    >>> Fe.density = Fe.molecular_mass/Fe.volume(a=2.8664)
-    >>> print("%.3g"%Fe.density)
+    >>> Fe_lattice = formula("2Fe")  # bcc lattice has 2 atoms per unit cell
+    >>> Fe_lattice.density = Fe_lattice.molecular_mass/Fe_lattice.volume(a=2.8664)
+    >>> print(f"{Fe_lattice.density:.3g}")
     7.88
-    >>> print("%.3g"%elements.Fe.density)
+    >>> print(f"{elements.Fe.density:.3g}")
     7.87
 
 Mixtures
@@ -249,13 +250,13 @@ following is a 2:1 mixture of water and heavy water:
     >>> H2O = formula('H2O',natural_density=1)
     >>> D2O = formula('D2O',natural_density=1)
     >>> mix = mix_by_volume(H2O,2,D2O,1)
-    >>> print("%s %.4g"%(mix,mix.density))
+    >>> print(f"{mix} {mix.density:.4g}")
     (H2O)2D2O 1.037
 
 Note that this is different from a 2:1 mixture by weight:
 
     >>> mix = mix_by_weight(H2O,2,D2O,1)
-    >>> print("%s %.4g"%(mix,mix.density))
+    >>> print(f"{mix} {mix.density:.4g}")
     (H2O)2.2234D2O 1.035
 
 Except in the simplest of cases, the density of the mixture cannot be
@@ -272,14 +273,14 @@ compute molar mass and neutron/xray scattering length density:
     >>> import periodictable
     >>> SiO2 = periodictable.formula('SiO2')
     >>> hydrated = SiO2 + periodictable.formula('3H2O')
-    >>> print('%s mass %s'%(hydrated,hydrated.mass))
+    >>> print(f"{hydrated} mass {hydrated.mass}")
     SiO2(H2O)3 mass 114.13014
     >>> rho,mu,inc = periodictable.neutron_sld('SiO2+3H2O',density=1.5,wavelength=4.75)
-    >>> print('%s neutron sld %.3g'%(hydrated,rho))
+    >>> print(f"{hydrated} neutron sld {rho:.3g}")
     SiO2(H2O)3 neutron sld 0.849
     >>> rho,mu = periodictable.xray_sld(hydrated,density=1.5,
     ... wavelength=periodictable.Cu.K_alpha)
-    >>> print('%s X-ray sld %.3g'%(hydrated,rho))
+    >>> print(f"{hydrated} X-ray sld {rho:.3g}")
     SiO2(H2O)3 X-ray sld 13.5
 
 Biomolecules

--- a/periodictable/formulas.py
+++ b/periodictable/formulas.py
@@ -672,7 +672,7 @@ def formula_grammar(table):
     separator = space+Literal('+').suppress()+space
 
     # Lookup the element in the element table
-    symbol = Regex("[A-Z][a-z]*")
+    symbol = Regex("[A-Z][a-z]?")
     symbol = symbol.setParseAction(lambda s, l, t: table.symbol(t[0]))
 
     # Translate isotope
@@ -751,13 +751,15 @@ def formula_grammar(table):
 
     partsep = space + Literal('//').suppress() + space
     percent = Literal('%').suppress()
-
-    weight_percent = Regex("%(w((eigh)?t)?|m(ass)?)").suppress() + space
+    weight = Regex("(w((eigh)?t)?|m(ass)?)").suppress()
+    volume = Regex("v(ol(ume)?)?").suppress()
+    weight_percent = (percent + weight) | (weight + percent) + space
+    volume_percent = (percent + volume) | (volume + percent) + space
     by_weight = (count + weight_percent + mixture
                  + ZeroOrMore(partsep+count+(weight_percent|percent)+mixture)
                  + partsep + mixture)
     def convert_by_weight(string, location, tokens):
-        """convert mixture by %wt or %mass"""
+        """convert mixture by wt% or mass%"""
         #print "by weight", tokens
         piece = tokens[1:-1:2] + [tokens[-1]]
         fract = [float(v) for v in tokens[:-1:2]]
@@ -770,12 +772,11 @@ def formula_grammar(table):
         return _mix_by_weight_pairs(zip(piece, fract))
     mixture_by_weight = by_weight.setParseAction(convert_by_weight)
 
-    volume_percent = Regex("%v(ol(ume)?)?").suppress() + space
     by_volume = (count + volume_percent + mixture
                  + ZeroOrMore(partsep+count+(volume_percent|percent)+mixture)
                  + partsep + mixture)
     def convert_by_volume(string, location, tokens):
-        """convert mixture by %vol"""
+        """convert mixture by vol%"""
         #print "by volume", tokens
         piece = tokens[1:-1:2] + [tokens[-1]]
         fract = [float(v) for v in tokens[:-1:2]]

--- a/periodictable/mass.py
+++ b/periodictable/mass.py
@@ -78,8 +78,8 @@ def mass(isotope):
             Atomic weight of the element.
 
     Reference:
-        *Wang. M., Huang. W. J., Kondev. F. G., Audi. G., Naimi. S., The AME
-        2020 atomic mass evaluation (II). Tables, graphs and references *
+        Wang. M., Huang. W. J., Kondev. F. G., Audi. G., Naimi. S., 
+        *The AME 2020 atomic mass evaluation (II). Tables, graphs and references*
     """
     return isotope._mass
 

--- a/test/test_formulas.py
+++ b/test/test_formulas.py
@@ -165,6 +165,8 @@ def test():
     check_formula(formula('1mm Fe // 1mm Ni'), formula('50%vol Fe // Ni'))
     check_formula(formula('50%vol Co // Ti'), formula('2mL Co // 2mL Ti'))
     check_formula(formula('50%wt Co // Ti'), formula('2g Co // 2g Ti'))
+    check_formula(formula('50vol% Co // Ti'), formula('2mL Co // 2mL Ti'))
+    check_formula(formula('50wt% Co // Ti'), formula('2g Co // 2g Ti'))
     check_formula(formula('2mL Co // 2mL Ti'), formula(((1.5922466356368357, Co), (1, Ti))))
     check_formula(formula('2g Co // 2g Ti'), formula(((1, Co), (1.231186412350889, Ti))))
     check_formula(formula('5g NaCl // 50mL H2O@1'), formula('5g NaCl // 50g H2O'))


### PR DESCRIPTION
Use the standard terminology for mixtures. The old %wt/%vol forms are still accepted, but they are not documented and will be removed if they cause any ambiguities in the formula grammar.