### PR TITLE
Add formula.element to accumulate across isotopes and ions

### DIFF
--- a/periodictable/formulas.py
+++ b/periodictable/formulas.py
@@ -931,7 +931,7 @@ def count_elements(compound, by_isotope=False):
     """
     total = {}
     # Note: could accumulate charge at the same time as counting elements.
-    for part, count in compound.atoms.items():
+    for part, count in formula(compound).atoms.items():
         # Resolve isotopes and ions to the underlying element. Four cases:
         #    isotope with charge needs fragment.element.element
         #    isotope without charge needs fragment.element

--- a/periodictable/formulas.py
+++ b/periodictable/formulas.py
@@ -333,7 +333,7 @@ class Formula(object):
         formula, summed across all subgroups. Isotopes and ions are considered
         equivalent.
         """
-        return _count_elements(self)
+        return count_elements(self)
 
     @property
     def elements_hill(self):
@@ -920,9 +920,14 @@ def _count_atoms(seq):
             total[atom] += atom_count*count
     return total
 
-def _count_elements(compound, by_isotope=False):
+def count_elements(compound, by_isotope=False):
     """
-    Traverse formula structure, counting the total number of atoms.
+    Composition of the molecule.
+
+    Returns {*element*: *count*, ...} where the *count* is the total number
+    of each element in the chemical formula, summed across all isotopes and
+    ionization levels. If *by_isotope* is True, then sum the individual isotopes
+    separately across all ionization levels.
     """
     total = {}
     # Note: could accumulate charge at the same time as counting elements.

--- a/test/test_formulas.py
+++ b/test/test_formulas.py
@@ -4,6 +4,7 @@ from pickle import loads, dumps
 
 from periodictable import Ca, C, O, H, Fe, Ni, Si, D, Na, Cl, Co, Ti, S
 from periodictable import formula, mix_by_weight, mix_by_volume
+import periodictable.formulas
 
 def test():
     ikaite = formula()
@@ -48,6 +49,10 @@ def test():
     # formula tree.
     assert formula("3HDS{6+}O{2-}3O[16]{2-}").elements == {S: 3, O: 12, H: 6}
     assert str(formula("HDS{6+}O{2-}3O[16]{2-}").elements_hill) == "H2O4S"
+    isotopes = periodictable.formulas.count_elements(
+        formula("HDS{6+}O{2-}3O[16]{2-}"), by_isotope=True
+    )
+    assert isotopes == {S: 1, O: 3, O[16]:1, H: 1, D: 1}
 
     # Check charge
     assert formula("P{5+}O{2-}4").charge == -3

--- a/test/test_formulas.py
+++ b/test/test_formulas.py
@@ -2,7 +2,7 @@ from __future__ import division
 from copy import deepcopy
 from pickle import loads, dumps
 
-from periodictable import Ca, C, O, H, Fe, Ni, Si, D, Na, Cl, Co, Ti
+from periodictable import Ca, C, O, H, Fe, Ni, Si, D, Na, Cl, Co, Ti, S
 from periodictable import formula, mix_by_weight, mix_by_volume
 
 def test():
@@ -42,6 +42,11 @@ def test():
 
     # Check atom count
     assert formula("Fe2O4+3H2O").atoms == {Fe: 2, O: 7, H: 6}
+
+    # Check element count. The formula includes element, charged element,
+    # isotope and charged isotope.
+    assert formula("HDS{6+}O{2-}3O[16]{2-}").elements == {S: 1, O: 4, H: 2}
+    assert str(formula("HDS{6+}O{2-}3O[16]{2-}").elements_hill) == "H2O4S"
 
     # Check charge
     assert formula("P{5+}O{2-}4").charge == -3

--- a/test/test_formulas.py
+++ b/test/test_formulas.py
@@ -44,8 +44,9 @@ def test():
     assert formula("Fe2O4+3H2O").atoms == {Fe: 2, O: 7, H: 6}
 
     # Check element count. The formula includes element, charged element,
-    # isotope and charged isotope.
-    assert formula("HDS{6+}O{2-}3O[16]{2-}").elements == {S: 1, O: 4, H: 2}
+    # isotope and charged isotope. The "3" in front forces recursion into a
+    # formula tree.
+    assert formula("3HDS{6+}O{2-}3O[16]{2-}").elements == {S: 3, O: 12, H: 6}
     assert str(formula("HDS{6+}O{2-}3O[16]{2-}").elements_hill) == "H2O4S"
 
     # Check charge


### PR DESCRIPTION
The existing formula.atoms attribute keeps the isotopes + charges separate when accumulating the components.

This proposal uses formula.elements to accumulate across isotopes and charges. It also adds formula.elements_hill to return a structure in hill notation order.

```python
>>> print(formula("HDS{6+}O{2-}3O[16]{2-}").elements_hill)
H2O4S
```

Having written this, several questions arise:

1. Will there be confusion between formula.elements and formula.atoms?
2. Do we want formula.isotopes for accumulating isotopes without charge?
3. If we are accumulating isotopes, do we want to turn natural abundance into isotope distributions?

I made the underlying count_elements() function public and gave it a by_isotopes flag.
```python
>>> from periodictable.formulas import count_elements, formula
>>> print(formula(count_elements("HDS{6+}O{2-}3O[16]{2-}")))
H2O4S
>>> print(formula(count_elements("HDS{6+}O{2-}3O[16]{2-}", by_isotope=True)))
HDO3O[16]S
```

I'll await comments from those who can use this functionality before merging.

Refs #14 
