### PR TITLE
Add fasta strings to the formula grammar

### DIFF
--- a/doc/sphinx/guide/formula_grammar.rst
+++ b/doc/sphinx/guide/formula_grammar.rst
@@ -153,13 +153,15 @@ The grammar used for parsing formula strings is the following:
     quantity   :: count unit part ('//' count unit part)*
     percentage :: count 'wt%|vol%' part ('//' count '%' part)* '//' part
     part       :: compound | '(' mixture ')'
-    compound   :: group (separator group)* density?
+    compound   :: (composite | fasta) density?
+    fasta      :: ('dna' | 'rna' | 'aa') ':' [A-Z -*]+
+    composite  :: group (separator group)*
     group      :: count element+ | '(' formula ')' count
     element    :: symbol isotope? ion? count?
     symbol     :: [A-Z][a-z]*
     isotope    :: '[' number ']'
     ion        :: '{' number? [+-] '}'
-    density    :: '@' count
+    density    :: '@' count [ni]?
     count      :: number | fraction
     number     :: [1-9][0-9]*
     fraction   :: ([1-9][0-9]* | 0)? '.' [0-9]*

--- a/periodictable/formulas.py
+++ b/periodictable/formulas.py
@@ -639,6 +639,7 @@ def _isotope_substitution(compound, source, target, portion=1):
     return formula(atoms, density=density)
 
 
+# TODO: Grammar should be independent of table
 # TODO: Parser can't handle meters as 'm' because it conflicts with the milli prefix
 LENGTH_UNITS = {'nm': 1e-9, 'um': 1e-6, 'mm': 1e-3, 'cm': 1e-2}
 MASS_UNITS = {'ng': 1e-9, 'ug': 1e-6, 'mg': 1e-3, 'g': 1e+0, 'kg': 1e+3}
@@ -662,6 +663,10 @@ def formula_grammar(table):
             an *element* or a list of pairs (*count, fragment*).
 
     """
+    # TODO: fix circular imports
+    # This ickiness is because the formula class returned from the circular
+    # import of fasta does not match the local formula class.
+    from .formulas import Formula
 
     # Recursive
     composite = Forward()
@@ -700,6 +705,7 @@ def formula_grammar(table):
     fasta = Regex("aa|rna|dna") + Literal(":").suppress() + Regex("[A-Z *-]+")
     def convert_fasta(string, location, tokens):
         #print("fasta", string, location, tokens)
+        # TODO: fasta is ignoring table when parsing
         # TODO: avoid circular imports
         # TODO: support other biochemicals (carbohydrate residues, lipids)
         from . import fasta
@@ -759,6 +765,7 @@ def formula_grammar(table):
         # Compound can be a sequence of (count, fragment) pairs, or if it is
         # a fasta sequence it may already be a formula.
         material = tokens[:-1] if tokens[-1] is None else tokens[:-2]
+        #print("compound", material, type(material[0]), len(material))
         if len(material) == 1 and isinstance(material[0], Formula):
             formula = material[0]
         else:

--- a/test/test_formulas.py
+++ b/test/test_formulas.py
@@ -182,6 +182,12 @@ def test():
 
     # fasta
     check_formula(formula('aa:A'), formula('C3H4H[1]NO'))
+    check_formula(formula('aa:RELEEL'), formula('C33H42H[1]11N9O12'))
+    check_formula(formula('aa:RELEEL'), formula('aa:RE-LEE L *UNUSED'))
+    check_formula(
+        formula('30%vol CCl4@1.2 //10% aa:RE-LE EL @1.8 // H2O@1'),
+        formula('30%vol CCl4@1.2 //10% C33H42H[1]11N9O12 @1.8 // H2O@1'))
+
 
 def check_mass(f1, mass, tol=1e-14):
     """Check that the total mass of f1 is as expected."""


### PR DESCRIPTION
FASTA strings can now be used as part of a mixture formula, such as `30%vol CCl4@1.2 //10% aa:RELEEL // H2O@1`. You can override the sequence density using `@{density}` as for other compounds.

Fixes #68 