### PR TITLE
MAINT: fixes for numpy 2

### DIFF
--- a/periodictable/nsf.py
+++ b/periodictable/nsf.py
@@ -564,7 +564,7 @@ def init(table, reload=False):
         # Note: Sears (1992) uses b = b' - i b'', so negate sigma_a for b''.
         # Warning: -b_c.imag may be -0, which can mess with your calculations.
         #if nsf.b_c is None: print(f"b_c unavailable for {columns[0]}")
-        b_c = nsf.b_c if nsf.b_c is not None else np.NaN
+        b_c = nsf.b_c if nsf.b_c is not None else np.nan
         b_c_i = -nsf.absorption/(2000*ABSORPTION_WAVELENGTH)
         nsf.b_c_complex = b_c + 1j*b_c_i
 

--- a/periodictable/xsf.py
+++ b/periodictable/xsf.py
@@ -261,7 +261,7 @@ class Xray(object):
                                     self.element.symbol.lower()+".nff")
             if self.element.symbol != 'n' and os.path.exists(filename):
                 xsf = numpy.loadtxt(filename, skiprows=1).T
-                xsf[1, xsf[1] == -9999.] = numpy.NaN
+                xsf[1, xsf[1] == -9999.] = numpy.nan
                 xsf[0] *= 0.001  # Use keV in table rather than eV
                 self._table = xsf
         return self._table


### PR DESCRIPTION
numpy version 2, which is in release candidate stage, has removed `np.NaN` as an alias to `np.nan`. Only `np.nan` is usable with numpy==2.
This PR removes the usage of `np.NaN` in the package. These issues were picked up during testing of a third party package, there may be other issues lurking for numpy 2 compatibility.

Would it be possible to release a new version to PyPI when/if this PR is merged?