### PR TITLE
feat: add functions to calculate δ, β, n, and k components of the ind…

### DIFF
--- a/periodictable/xsf.py
+++ b/periodictable/xsf.py
@@ -528,7 +528,7 @@ def beta(compound, *, density=None, natural_density=None,
 
         n = 1 - \delta + i \beta
 
-    derivitive of the formula http://xdb.lbl.gov (section 1.7) using a more common
+    derivative of the formula http://xdb.lbl.gov (section 1.7) using a more common
     sign convention for the imaginary part of the index of refraction. Checked
     against http://henke.lbl.gov/optical_constants/getdb2.html.
     """


### PR DESCRIPTION
This pull request adds new utility functions to the `periodictable/xsf.py` module to enable more granular calculations of the index of refraction for X-ray scattering. These functions allow users to separately compute the δ (delta), β (beta), n (real part), and k (imaginary part) components, improving the flexibility and clarity of the API for scientific usage.

Resolves #103 

New index of refraction component calculations:

* Added the `delta` function to calculate the δ component of the index of refraction for a compound, with support for both energy and wavelength inputs.
* Added the `beta` function to calculate the β component of the index of refraction for a compound, using a standard sign convention for the imaginary part.

Convenience functions for real and imaginary parts:

* Added the `n` function to compute the real part of the index of refraction (`n = 1 - delta`).
* Added the `k` function to compute the imaginary part of the index of refraction (`k = beta`).

### TODO:
There are still some things that I have not checked. 
- [ ] Ensure doc strings are consistent with the rest of the document.
- [ ] Check math in doc strings is consistent with documentation guidelines.
- [ ] Check docs build correctly. 