### PR TITLE
Perf: Optimize string concatenation in parse_uncertainty

### DIFF
--- a/periodictable/util.py
+++ b/periodictable/util.py
@@ -47,7 +47,7 @@ def parse_uncertainty(s):
         # e.g., 23.0035(12) but not 23(1) or 23.0(1.0) or 23(1.0)
         if '.' not in unc and '.' in value:
             zeros = len(value.split('.')[1]) - len(unc)
-            unc = "0." + ("0"*zeros) + unc
+            unc = "".join(["0.", "0" * zeros, unc])
         return float(value), float(unc)
 
     # Plain value with no uncertainty


### PR DESCRIPTION
This pull request optimizes string construction in `parse_uncertainty` by replacing `+` concatenation with `.join()`.

The Issue: In Python, strings are immutable. Using `+` to combine multiple string segments forces the interpreter to create a new string object and copy the content for every concatenation step. This results in inefficient memory usage and unnecessary overhead, particularly when constructing strings from multiple parts.

The Solution: I refactored the string construction logic to use `''.join()`. This approach ensures linear time complexity `O(n)` because the total size of the final string is calculated once, and memory is allocated efficiently.

This is in line with standard python performance recommendation: https://peps.python.org/pep-0008/#programming-recommendations